### PR TITLE
[40기 전민식] ADD: product-list API

### DIFF
--- a/src/controllers/productController.js
+++ b/src/controllers/productController.js
@@ -1,4 +1,3 @@
-const { query } = require('express')
 const productService = require('../services/productService')
 const { catchAsync } = require('../utils/error')
 
@@ -8,6 +7,13 @@ const getProductById = catchAsync(async (req, res) => {
     res.status(200).json({ data : result })
 })
 
+const getAllProducts = catchAsync(async (req, res) => {
+    const {categoryId, size, orderBy} = req.query
+        const data = await productService.getAllProducts(categoryId, size, orderBy)
+        res.status(200).json({ data })
+})
+
 module.exports = {
-    getProductById
+    getProductById,
+    getAllProducts
 }

--- a/src/models/productDao.js
+++ b/src/models/productDao.js
@@ -1,5 +1,121 @@
 const dataSource = require('./data-source')
 
+const whereSet = {
+    DEFAULT : '',
+    TRUE : 'WHERE'
+}
+
+const andSet = {
+    DEFAULT : '',
+    TRUE : 'AND'
+}
+
+const joinSet = {
+    DEFAULT : '',
+    OPTIONS : 'LEFT JOIN options AS op ON op.product_id = p.id',
+    BIDS : 'LEFT JOIN bids AS b ON op.id = b.option_id'
+}
+
+const getAllProducts = async (categoryId, size, orderBy) => {
+    try {
+
+        const categorySet = {
+            DEFAULT : '',
+            [categoryId] : `p.category_id = ${categoryId}`,
+        }
+
+        const sizeSet = {
+            DEFAULT : '',
+            [size] : `op.size = '${size}'`,
+        }
+
+        if(!categoryId && !size) 
+            {joinOption = 'DEFAULT'; where = 'DEFAULT'; categoryId = 'DEFAULT'; and = 'DEFAULT'; size = 'DEFAULT'; and2 = 'DEFAULT';}
+        else if(categoryId && !size)
+            {joinOption = 'DEFAULT'; where = 'TRUE'; categoryId; and = 'DEFAULT'; size = 'DEFAULT'; and2 = 'DEFAULT';}
+        else if(size && !categoryId) 
+            {joinOption = 'OPTIONS'; where = 'TRUE'; categoryId = 'DEFAULT'; and = 'DEFAULT'; size; and2 = 'TRUE';}
+        else if(categoryId && size) 
+            {joinOption = 'OPTIONS'; where = 'TRUE'; categoryId; and = 'TRUE'; size; and2 = 'TRUE';}
+
+        const getProductId = await dataSource.query(`
+            SELECT p.id FROM products AS p
+            ${joinSet[joinOption]}
+            ${whereSet[where]}
+            ${categorySet[categoryId]}
+            ${andSet[and]}
+            ${sizeSet[size]}
+        `)
+
+        let returnData = [];
+
+        for (let i=0; i<getProductId.length; i++) {
+            const getPrices = await dataSource.query(`
+                SELECT b.price FROM bids AS b
+                LEFT JOIN options AS op ON b.option_id = op.id
+                LEFT JOIN products AS p ON op.product_id = p.id
+                LEFT JOIN orders AS o ON b.id = o.bid_id
+                WHERE p.id = ?
+                AND b.type_id = 2
+                AND b.id NOT IN (SELECT bid_id FROM orders)
+                ${andSet[and2]}
+                ${sizeSet[size]}              
+                ORDER BY b.price ASC;
+            `, [getProductId[i].id]
+            )
+            
+            if (typeof getPrices[0] == 'undefined') {
+                returnData.push({id : getProductId[i].id, price : ''})
+            } else {
+                returnData.push({id : getProductId[i].id, price : getPrices[0].price})
+            }
+        }
+
+        for (let i=0; i<getProductId.length; i++) {
+            const getOtherProductsData = await dataSource.query(`
+                SELECT
+                    p.thumbnail_image_url AS thumbnailImageUrl,
+                    b.name AS brandName,
+                    p.en_name AS enName,
+                    p.kr_name AS krName,
+                    p.release_date AS releaseDate
+                FROM products AS p
+                LEFT JOIN brands AS b ON b.id = p.brand_id
+                WHERE p.id = ?
+            `, [getProductId[i].id]
+            )
+            returnData[i].thumbnailImageUrl = getOtherProductsData[0].thumbnailImageUrl
+            returnData[i].brandName = getOtherProductsData[0].brandName
+            returnData[i].enName = getOtherProductsData[0].enName
+            returnData[i].krName = getOtherProductsData[0].krName
+            returnData[i].releaseDate = getOtherProductsData[0].releaseDate
+        }
+
+        if (!orderBy) {
+            returnData = returnData
+        } else if (orderBy == 'priceHighToLow') {
+            let arr = [];
+
+            for (let i=0; i<returnData.length; i++) {
+                if (returnData[i].price !== '') {
+                    arr.push(returnData[i])
+                }
+            }
+
+            arr.sort((a, b) => b.price - a.price)
+            returnData = arr;
+        } else if (orderBy == 'releaseDate') {
+
+            returnData = returnData.sort((a, b) => b.releaseDate - a.releaseDate)
+        }
+
+        return returnData   
+    } catch (err){
+        console.log(err)
+        throw new Error('getAllProductsErr')
+    }
+}
+
 const getConstantProductDataById = async (productId) => {
     return await dataSource.query(`
         SELECT
@@ -125,5 +241,6 @@ const getProductChartDataById = async (productId) => {
 module.exports = {
     getConstantProductDataById,
     getProductTradeDataById,
-    getProductChartDataById
+    getProductChartDataById,
+    getAllProducts
 }

--- a/src/routes/productRouter.js
+++ b/src/routes/productRouter.js
@@ -3,6 +3,8 @@ const productController = require('../controllers/productController');
 
 const routes = express.Router();
 
+routes.get('', productController.getAllProducts)
+routes.get('/main', productController.getAllProducts)
 routes.get('/:productId', productController.getProductById)
 
 module.exports = {

--- a/src/services/productService.js
+++ b/src/services/productService.js
@@ -17,6 +17,11 @@ const getProductById = async (productId) => {
     }
 }
 
+const getAllProducts = async (categoryId, size, orderBy) => {
+    return await productDao.getAllProducts(categoryId, size, orderBy)
+}
+
 module.exports = {
-    getProductById
+    getProductById,
+    getAllProducts
 }

--- a/tests/product.test.js
+++ b/tests/product.test.js
@@ -27,5 +27,16 @@ describe("GET Products", () => {
             .expect(200);
     });
 
+    test("SUCCESS: getAllProducts", async () => {
+        await request(app)
+            .get("/products")
+            .expect(200);
+    });
+
+    test("SUCCESS: filters", async () => {
+        await request(app)
+            .get("/products?size=230&categoryId=1&sortBy=releaseDate")
+            .expect(200);
+    });
 })
 


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 데이터베이스 작업
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 제품 리스트 페이지 조회 기능 API 추가
- 필터 적용
- 정렬 적용

<br />

## :: 구현 사항 설명  
- 모든 제품의 제일 낮은 판매입찰 가격과 상세정보 보내주기
- 필터는 size, categoryId 두 가지로 나뉘어지고, 각 필터 안에서 한개씩 선택이 가능하다.
- 정렬은 프리미엄(고가격순) 그리고 발매일순, 2가지로 나뉘어진다.


<br />

## :: 테스트 결과 이미지
1. 모든 제품 조회
![Screen Shot 2023-01-03 at 9 05 56 PM](https://user-images.githubusercontent.com/111173900/210354112-f3c3f918-4af7-4df8-9d69-8cd48c9b1216.png)

2. 필터 & 정렬 적용
![Screen Shot 2023-01-03 at 9 10 32 PM](https://user-images.githubusercontent.com/111173900/210354812-03ffe249-308d-4b13-837b-09a149a14ed4.png)

3. Unit Test
![Screen Shot 2023-01-03 at 9 13 41 PM](https://user-images.githubusercontent.com/111173900/210355209-98fb26bc-9b94-4247-b3da-13c4a8e14360.png)


<br />

## :: 기타 질문 및 특이 사항
- DAO 파일에서 query를 for loop 안에 사용해서 db hit이 커지는데 다른 방법이 있을까요?

## :: TRELLO
https://trello.com/c/w85Z38Uy